### PR TITLE
Add Node.js SSH terminal scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.MD
+++ b/README.MD
@@ -43,6 +43,16 @@ git clone https://github.com/your-org/ai-dev-assistant.git
 cd ai-dev-assistant
 ```
 
+### SSH Terminal Tool
+
+Install dependencies and start a shell session on a remote host:
+```bash
+npm install
+node index.js <host> <user> <password>
+```
+Credentials can also be provided via `SSH_HOST`, `SSH_USER` and `SSH_PASS` environment variables.
+
+
 ## 🧩 Future Ideas
 
 * VS Code plugin version

--- a/index.js
+++ b/index.js
@@ -1,0 +1,34 @@
+const { Client } = require('ssh2');
+
+const host = process.argv[2] || process.env.SSH_HOST;
+const username = process.argv[3] || process.env.SSH_USER;
+const password = process.argv[4] || process.env.SSH_PASS;
+
+if (!host || !username || !password) {
+  console.log('Usage: node index.js <host> <username> <password>');
+  process.exit(1);
+}
+
+const conn = new Client();
+conn.on('ready', () => {
+  console.log('SSH connection established. Opening shell...');
+  conn.shell((err, stream) => {
+    if (err) {
+      console.error('Shell error:', err);
+      conn.end();
+      return;
+    }
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.pipe(stream);
+    stream.pipe(process.stdout);
+    stream.stderr.pipe(process.stderr);
+    stream.on('close', () => {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+      conn.end();
+    });
+  });
+}).on('error', (err) => {
+  console.error('Connection error:', err);
+}).connect({ host, username, password });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,92 @@
+{
+  "name": "ssh-terminal-tool",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ssh-terminal-tool",
+      "version": "0.1.0",
+      "dependencies": {
+        "ssh2": "^1.11.0"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/ssh2": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
+      "integrity": "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.20.0"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ssh-terminal-tool",
+  "version": "0.1.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "ssh2": "^1.11.0"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Node.js project for SSH terminal tool
- create basic SSH shell script
- document usage instructions
- ignore dependencies with `.gitignore`

## Testing
- `npm install`
- `npm test`
- `node index.js` *(fails: Usage message)*

------
https://chatgpt.com/codex/tasks/task_e_68491716b370832da3b067a5dd193d7a